### PR TITLE
Switch to Sha256 and port over go-cpace tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 keywords = ["crypto", "cryptography", "ristretto", "pake", "cpace"]
 
 [dependencies]
-thiserror = "1.0.14"
-curve25519-dalek = "2.0.0"
-hkdf = "0.8"
+thiserror = "1.0.20"
+curve25519-dalek = "3.0.0"
+hkdf = "0.9"
 rand_core = "0.5"
-sha2 = "0.8.1"
+sha2 = "0.9.1"
 
 [dev-dependencies]
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ rand_core = "0.5"
 sha2 = "0.9.1"
 
 [dev-dependencies]
+base64 = "0.12"
 rand = "0.7"
+hex = "0.4"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,3 +1,4 @@
+use core::convert::TryInto;
 use rand::rngs::OsRng;
 
 use cpace;
@@ -9,7 +10,7 @@ fn key_agreement() {
         cpace::Context {
             initiator_id: "Alice",
             responder_id: "Bob",
-            associated_data: b"",
+            associated_data: &[],
         },
         OsRng,
     )
@@ -21,7 +22,7 @@ fn key_agreement() {
         cpace::Context {
             initiator_id: "Alice",
             responder_id: "Bob",
-            associated_data: b"",
+            associated_data: &[],
         },
         OsRng,
     )
@@ -31,3 +32,320 @@ fn key_agreement() {
 
     assert_eq!(alice_key.0[..], bob_key.0[..]);
 }
+
+// These tests are ported over from https://github.com/FiloSottile/go-cpace-ristretto255/blob/master/cpace_test.go
+#[test]
+fn large_context_values() {
+    const TOO_LARGE: usize = 1 << 16;
+
+    let valid_context = cpace::Context {
+        initiator_id: &"a".repeat(1 << (16 - 1)),
+        responder_id: "b",
+        associated_data: &[],
+    };
+
+    let (init_msg, state) = cpace::init("password", valid_context.clone(), OsRng)
+        .expect("1 << 16 - 1 should be a valid initator size");
+
+    let (bob_key, rsp_msg) = cpace::respond(init_msg, "password", valid_context.clone(), OsRng)
+        .expect("A valid context should be valid to respond to");
+
+    let alice_key = state.recv(rsp_msg).unwrap();
+
+    assert_eq!(alice_key.0[..], bob_key.0[..]);
+
+    let invalid_context = cpace::Context {
+        initiator_id: &"a".repeat(TOO_LARGE),
+        responder_id: "b",
+        associated_data: &[],
+    };
+
+    let res = cpace::init("password", invalid_context, OsRng);
+
+    assert!(matches!(
+        res,
+        Err(cpace::Error::InitiatorIdTooLong(TOO_LARGE))
+    ));
+}
+
+#[test]
+fn broken_message() {
+    let context = cpace::Context {
+        initiator_id: "192.0.2.1:12345",
+        responder_id: "192.0.2.2:42",
+        associated_data: &[],
+    };
+
+    let (init_msg, state) = cpace::init("password", context, OsRng).unwrap();
+
+    // Initator too short not possible because the type system restricts the `InitMessage`
+    // construction to force the array to be 48 bytes in length.
+
+    {
+        let mut init_msg_bytes = init_msg.0;
+
+        init_msg_bytes[init_msg_bytes.len() - 1] ^= 0xff;
+        let malformed_bytes = init_msg_bytes.try_into().unwrap();
+        let malformed_init_msg = cpace::InitMessage(malformed_bytes);
+
+        let res = cpace::respond(malformed_init_msg, "password", context, OsRng);
+
+        assert!(matches!(res, Err(cpace::Error::InvalidPoint)));
+    }
+
+    let (_, rsp_msg) = cpace::respond(init_msg, "password", context, OsRng).unwrap();
+
+    // The receiver being too short not possible because the type system restricts the `ResponseMessage` construction
+    // to force the array to be 32 bytes in length.
+
+    {
+        let mut rsp_msg_bytes = rsp_msg.0;
+
+        rsp_msg_bytes[rsp_msg_bytes.len() - 1] ^= 0xff;
+        let malformed_bytes = rsp_msg_bytes.try_into().unwrap();
+        let malformed_rsp_msg = cpace::ResponseMessage(malformed_bytes);
+        let res = state.recv(malformed_rsp_msg);
+
+        assert!(matches!(res, Err(cpace::Error::InvalidPoint)))
+    }
+}
+
+struct Test<'ctx> {
+    name: &'static str,
+    password_a: &'static str,
+    password_b: &'static str,
+    context_a: cpace::Context<'ctx>,
+    context_b: cpace::Context<'ctx>,
+}
+
+const VALID_TEST_PAIRS: &[Test] = &[
+    Test {
+        name: "valid, without ad",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "valid, with ad",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: b"x",
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: b"x",
+        },
+    },
+    Test {
+        name: "valid, equal identities",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+];
+
+const INVALID_TEST_PAIRS: &[Test] = &[
+    Test {
+        name: "different passwords",
+        password_a: "p",
+        password_b: "P",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "different identity a",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "x",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "different identity b",
+        password_a: "p",
+        password_b: "b",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "x",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "different ad",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: b"foo",
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: b"bar",
+        },
+    },
+    Test {
+        name: "swapped identities",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "b",
+            responder_id: "a",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "missing ad",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: b"x",
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "identity concatenation",
+        password_a: "p",
+        password_b: "p",
+        context_a: cpace::Context {
+            initiator_id: "ax",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "xb",
+            associated_data: &[],
+        },
+    },
+    Test {
+        name: "empty password",
+        password_a: "p",
+        password_b: "",
+        context_a: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+        context_b: cpace::Context {
+            initiator_id: "a",
+            responder_id: "b",
+            associated_data: &[],
+        },
+    },
+];
+
+fn do_exchange(test_case: &Test) -> (cpace::Key, cpace::Key) {
+    let (init_msg, state) = match cpace::init(test_case.password_a, test_case.context_a, OsRng) {
+        Ok((init_msg, state)) => (init_msg, state),
+        _ => panic!(
+            "Test case '{}' should be able to start the protocol!",
+            test_case.name
+        ),
+    };
+
+    let (bob_key, rsp_msg) =
+        match cpace::respond(init_msg, test_case.password_b, test_case.context_b, OsRng) {
+            Ok((bob_key, rsp_msg)) => (bob_key, rsp_msg),
+            _ => panic!(
+                "Test case '{}' should be able to respond to the inital message!",
+                test_case.name
+            ),
+        };
+
+    let alice_key = match state.recv(rsp_msg) {
+        Ok(key) => key,
+        _ => panic!(
+            "Test case '{}' should be able to get the shared key!",
+            test_case.name
+        ),
+    };
+
+    (alice_key, bob_key)
+}
+
+const OUT_KEY_SIZE: usize = 32;
+
+#[test]
+fn test_valid_case_sets() {
+    for test_case in VALID_TEST_PAIRS {
+        let (alice_key, bob_key) = do_exchange(test_case);
+        assert_eq!(
+            alice_key.0[..],
+            bob_key.0[..],
+            "The two parties should have shared keys!"
+        );
+
+        assert_eq!(alice_key.0.len(), OUT_KEY_SIZE);
+        assert_eq!(bob_key.0.len(), OUT_KEY_SIZE);
+    }
+}
+
+#[test]
+fn test_invalid_case_sets() {
+    for test_case in INVALID_TEST_PAIRS {
+        let (alice_key, bob_key) = do_exchange(test_case);
+
+        assert_eq!(alice_key.0.len(), OUT_KEY_SIZE);
+        assert_eq!(bob_key.0.len(), OUT_KEY_SIZE);
+
+        assert_ne!(alice_key.0[..], bob_key.0[..])
+    }
+}
+
+// testIdentity not ported because the Rust Ristretto point
+// implementation doesn't have the equivalent of `point.Encode()`.

--- a/tests/transcript.rs
+++ b/tests/transcript.rs
@@ -1,0 +1,88 @@
+use rand_core::{CryptoRng, RngCore};
+use sha2::{Digest, Sha256};
+
+use cpace;
+
+// These are the first 200 bytes (hex encoded) from the go-cpace transcript test seeded RNG.
+// It uses HKDF<SHA256> with a IKM of b"INSECURE".
+const RNG_SEEDED_BYTES: &str = "11ab582caf3635b3801183db14a5a5bb38e513217316f8606c7d8f6dc955076d2479483a11aaf7d89bfd04c6971b56c1ca5f84080081b47df5cc9ba0e25bc0a894f7476153423d4487f2f75e55a0b7a608092044474aba5219db27d985d4f507ca835cd943783d58d8c5311bb2fb2999f36ba85c46c19be6d65066b398d2aff43f8c854983f4365202b3c706c1ded7f5b06a3389b57b4bd43631d53f810ed6135eb399fff4103482c19a506c6dde2eeaaaf84bc8dc8e198a01873f88678b41f9b0493d7480996439";
+
+struct TestingRng {
+    byte_pool: Vec<u8>,
+}
+
+// "Don't try this at home" -- FiloSottile
+impl RngCore for TestingRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.byte_pool.remove(0) as u64
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let dest_len = dest.len();
+        dest[..].copy_from_slice(&self.byte_pool[..dest_len]);
+        self.byte_pool.drain(..dest.len()).count();
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        Ok(self.fill_bytes(dest))
+    }
+}
+
+// "Really don't try this at home" -- Fox
+impl CryptoRng for TestingRng {}
+
+const PASSWORD: &str = "password";
+
+const CONTEXT: cpace::Context = cpace::Context {
+    initiator_id: "a",
+    responder_id: "b",
+    associated_data: b"ad",
+};
+
+const EXPECTED_INIT_MSG: &str = "11ab582caf3635b3801183db14a5a5bb14575029b4fa53c53a9fca55e7ab4aab9179d5530fbdb70d172bc8b8cf521d35";
+const EXPECTED_RSP_MSG: &str = "a229fc634fe3a760361e56d8dab37b9befe941cd62290eba324a9e25f73d1312";
+
+const EXPECTED_SHARED_KEY: &str =
+    "54ccaa1f1d24b270075157549c54942adef8331ef733a17ffebe72b6dd663e89";
+
+const EXPECTED_FINAL_TRANSCRIPT: &str = "NpHB1PcNLBGo9idbTXys5aRkuAlV+FQAshGfsJoxs3g";
+
+#[test]
+fn transcript() {
+    let seed = hex::decode(&RNG_SEEDED_BYTES).unwrap();
+
+    let mut rng = TestingRng { byte_pool: seed };
+
+    let mut tx = Sha256::new();
+
+    let (init_msg, state) = cpace::init(PASSWORD, CONTEXT, &mut rng).unwrap();
+
+    tx.update(&init_msg.0.as_ref());
+
+    let found_init_msg = hex::encode(&init_msg.0.as_ref());
+    assert_eq!(&found_init_msg, EXPECTED_INIT_MSG);
+
+    let (bob_key, rsp_msg) = cpace::respond(init_msg, PASSWORD, CONTEXT, &mut rng).unwrap();
+
+    tx.update(&rsp_msg.0.as_ref());
+    tx.update(&bob_key.0);
+
+    let found_rsp_msg = hex::encode(&rsp_msg.0);
+    assert_eq!(&found_rsp_msg, EXPECTED_RSP_MSG);
+
+    let alice_key = state.recv(rsp_msg).unwrap();
+
+    assert_eq!(alice_key.0[..], bob_key.0[..]);
+    assert_eq!(
+        alice_key.0[..],
+        hex::decode(EXPECTED_SHARED_KEY).unwrap()[..]
+    );
+
+    let digest = tx.finalize();
+    let found_sum = base64::encode_config(&digest, base64::STANDARD_NO_PAD);
+    assert_eq!(&found_sum, EXPECTED_FINAL_TRANSCRIPT);
+}


### PR DESCRIPTION
I finally had the time to take a look back at this repo and I was happy to see that the Go implementation switched over the SHA256 so some of `cpace`'s `XXX` markers could be resolved. In the process of switching to SHA256, I also ported over all of the "basic tests" that were applicable from [Filippo's implementation](https://github.com/FiloSottile/go-cpace-ristretto255/blob/master/cpace_test.go).

I also added the transcript test. I mocked the RNG by dumping some bytes in hex from the Go test and then using that as a "entropy pool" for a faked RNG that could act in place of  `OsRng`. So now at least we know, and backed by a test, that it is interoperable with another implementation. 

Closes #1, #2, #3 